### PR TITLE
entity-tracker-component 2.0.0 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,15 @@ language: php
 
 matrix:
     include:
-        - php: 5.5
         - php: 5.6
         - php: 7.0
+        - php: 7.0
+          env: deps=lowest
+        - php: 7.1
         - php: hhvm
     allow_failures:
         - php: hhvm
 
 install:
-    - composer install --prefer-source
+    - if [ -z "$deps" ]; then composer install; fi;
+    - if [ "$deps" = "lowest" ]; then composer update --prefer-lowest -n; fi;

--- a/composer.json
+++ b/composer.json
@@ -3,16 +3,16 @@
     "description":       "Wraps around the hostnet/entity-tracker-component and allows configuration of several listener components",
     "license":           "MIT",
     "require": {
-        "php":                              ">=5.5",
-        "hostnet/entity-tracker-component": "^1.2.0",
-        "psr/log":                          "1.*",
+        "php":                              "5.*,>=5.6||7.*",
+        "hostnet/entity-tracker-component": "^2.0.0",
+        "psr/log":                          "^1.0.0",
         "symfony/config":                   "^3.0|^2.6",
         "symfony/dependency-injection":     "^3.0|^2.6",
         "symfony/http-kernel":              "^3.0|^2.6"
     },
     "require-dev": {
-        "hostnet/entity-blamable-component": "^1.0",
-        "phpunit/phpunit":                   "5.*|4.*",
+        "hostnet/entity-blamable-component": "^1.0.0",
+        "phpunit/phpunit":                   "^5.5.0",
         "symfony/security":                  "^3.0|^2.6",
         "symfony/security-bundle":           "^3.0|^2.6"
     },
@@ -20,9 +20,6 @@
         "hostnet/entity-revision-component": "Provides the @Revision annotation and listeners",
         "hostnet/entity-mutation-component": "Provides the @Mutation annotation and listeners",
         "hostnet/entity-blamable-component": "Provides the @Blamable annotation and listeners"
-    },
-    "conflict": {
-        "hostnet/entity-revision-component": "<1.1"
     },
     "minimum-stability": "stable",
     "autoload": {

--- a/src/Resources/config/services.yml
+++ b/src/Resources/config/services.yml
@@ -18,3 +18,4 @@ services:
             - "@?logger"
         tags:
             - { name: doctrine.event_listener, event: preFlush, priority: 15 }
+            - { name: doctrine.event_listener, event: prePersist, priority: 15 }

--- a/test/Services/Blamable/DefaultBlamableProviderTest.php
+++ b/test/Services/Blamable/DefaultBlamableProviderTest.php
@@ -13,8 +13,7 @@ class DefaultBlamableProviderTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->token_storage = $this->getMock(
-            'Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'
+        $this->token_storage = $this->createMock('Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface'
         );
     }
 


### PR DESCRIPTION
* phpunit 5.5
* dropped support for php 5.5
* added travis build for lowest dependencies allowed