### PR TITLE
Configure a shared cache for storing resolved annotations and attribute values

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "minimum-stability": "stable",
     "require": {
         "php":                              "^8.3",
-        "hostnet/entity-tracker-component": "^2.0.0",
+        "hostnet/entity-tracker-component": "^2.3.0",
         "psr/log":                          "^1.1.0||^2.0.0||^3.0.0",
         "symfony/config":                   "^5.4||^6.0",
         "symfony/dependency-injection":     "^5.4||^6.0",
@@ -13,7 +13,7 @@
         "symfony/yaml":                     "^5.4||^6.0"
     },
     "require-dev": {
-        "hostnet/entity-blamable-component": "^1.0.4",
+        "hostnet/entity-blamable-component": "^1.1.0",
         "hostnet/phpcs-tool":                "^9.1.0",
         "phpspec/prophecy":                  "^1.19",
         "phpspec/prophecy-phpunit":          "^2.2",
@@ -22,15 +22,14 @@
         "symfony/security-bundle":           "^5.4||^6.0"
     },
     "suggest": {
-        "hostnet/entity-blamable-component": "Provides the @Blamable annotation and listeners",
-        "hostnet/entity-mutation-component": "Provides the @Mutation annotation and listeners",
-        "hostnet/entity-revision-component": "Provides the @Revision annotation and listeners"
+        "hostnet/entity-blamable-component": "Provides the @Blamable annotation/attribute and listeners",
+        "hostnet/entity-mutation-component": "Provides the @Mutation annotation/attribute and listeners",
+        "hostnet/entity-revision-component": "Provides the @Revision annotation/attribute and listeners"
     },
     "conflict": {
-        "hostnet/entity-blamable-component": "<=1.0.7",
-        "hostnet/entity-mutation-component": "<=1.0.7",
-        "hostnet/entity-revision-component": "<=1.1.8",
-        "hostnet/entity-tracker-component":  "<=2.2.3"
+        "hostnet/entity-blamable-component": "<1.1.0",
+        "hostnet/entity-mutation-component": "<1.1.0",
+        "hostnet/entity-revision-component": "<1.2.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,12 @@
         "hostnet/entity-mutation-component": "Provides the @Mutation annotation and listeners",
         "hostnet/entity-revision-component": "Provides the @Revision annotation and listeners"
     },
+    "conflict": {
+        "hostnet/entity-blamable-component": "<=1.0.7",
+        "hostnet/entity-mutation-component": "<=1.0.7",
+        "hostnet/entity-revision-component": "<=1.1.8",
+        "hostnet/entity-tracker-component":  "<=2.2.3"
+    },
     "autoload": {
         "psr-4": {
             "Hostnet\\Bundle\\EntityTrackerBundle\\": "src/"

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -57,7 +57,11 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('mutation')
                     ->info(sprintf($component_info, 'mutation'))
                 ->end()
-            ->end();
+                ->scalarNode('cache')
+                    ->info('Specifies cacheadapter service to use')
+                    ->cannotBeEmpty()
+                    ->defaultValue('entity_tracker.cache')
+                ->end();
 
         return $tree_builder;
     }

--- a/src/DependencyInjection/HostnetEntityTrackerExtension.php
+++ b/src/DependencyInjection/HostnetEntityTrackerExtension.php
@@ -26,6 +26,11 @@ class HostnetEntityTrackerExtension extends Extension
 
         $loader->load('services.yaml');
 
+        $cache = $config['cache'];
+        $container
+            ->getDefinition('entity_tracker.listener.entity_changed')
+            ->replaceArgument(3, new Reference($cache));
+
         if (\array_key_exists('blamable', $config)) {
             $this->validateComponent(self::BLAMABLE, 'blamable');
             $loader->load('blamable.yaml');
@@ -37,7 +42,8 @@ class HostnetEntityTrackerExtension extends Extension
 
             $container
                 ->getDefinition('entity_tracker.listener.blamable')
-                ->replaceArgument(1, new Reference($config['blamable']['provider']));
+                ->replaceArgument(1, new Reference($config['blamable']['provider']))
+                ->replaceArgument(2, new Reference($cache));
 
             if (isset($config['blamable']['default_username'])) {
                 $container
@@ -53,7 +59,8 @@ class HostnetEntityTrackerExtension extends Extension
             $loader->load('revision.yaml');
             $container
                 ->getDefinition('entity_tracker.listener.revision')
-                ->replaceArgument(1, new Reference($config['revision']['factory']));
+                ->replaceArgument(1, new Reference($config['revision']['factory']))
+                ->replaceArgument(3, new Reference($cache));
         } else {
             $this->validateClass(self::REVISION, 'revision');
         }
@@ -61,6 +68,10 @@ class HostnetEntityTrackerExtension extends Extension
         if (\array_key_exists('mutation', $config)) {
             $this->validateComponent(self::MUTATION, 'mutation');
             $loader->load('mutation.yaml');
+
+            $container
+                ->getDefinition('entity_tracker.listener.mutation')
+                ->replaceArgument(1, new Reference($cache));
         } else {
             $this->validateClass(self::MUTATION, 'mutation');
         }

--- a/src/Resources/config/blamable.yaml
+++ b/src/Resources/config/blamable.yaml
@@ -9,6 +9,7 @@ services:
         arguments:
             - "@entity_tracker.resolver.blamable"
             - "" # provider id, (configurable)
+            - ""
         tags:
             - { name: doctrine.event_listener, event: entityChanged, priority: 32, method: onEntityChanged }
 

--- a/src/Resources/config/blamable.yaml
+++ b/src/Resources/config/blamable.yaml
@@ -9,7 +9,7 @@ services:
         arguments:
             - "@entity_tracker.resolver.blamable"
             - "" # provider id, (configurable)
-            - ""
+            - "" # cacheadapter id (configurable, entity_tracker.cache by default)
         tags:
             - { name: doctrine.event_listener, event: entityChanged, priority: 32, method: onEntityChanged }
 

--- a/src/Resources/config/mutation.yaml
+++ b/src/Resources/config/mutation.yaml
@@ -8,5 +8,6 @@ services:
         class: Hostnet\Component\EntityMutation\Listener\MutationListener
         arguments:
             - "@entity_tracker.resolver.mutation"
+            - ""
         tags:
             - { name: doctrine.event_listener, event: entityChanged, priority: 8 }

--- a/src/Resources/config/mutation.yaml
+++ b/src/Resources/config/mutation.yaml
@@ -8,6 +8,6 @@ services:
         class: Hostnet\Component\EntityMutation\Listener\MutationListener
         arguments:
             - "@entity_tracker.resolver.mutation"
-            - ""
+            - "" # cacheadapter id (configurable, entity_tracker.cache by default)
         tags:
             - { name: doctrine.event_listener, event: entityChanged, priority: 8 }

--- a/src/Resources/config/revision.yaml
+++ b/src/Resources/config/revision.yaml
@@ -10,6 +10,7 @@ services:
             - "@entity_tracker.resolver.revision"
             - "" # factory service id, (configurable)
             - "@logger"
+            - ""
         tags:
             - { name: doctrine.event_listener, event: entityChanged, priority: 16 }
             - { name: doctrine.event_listener, event: postFlush, priority: 20 }

--- a/src/Resources/config/revision.yaml
+++ b/src/Resources/config/revision.yaml
@@ -10,7 +10,7 @@ services:
             - "@entity_tracker.resolver.revision"
             - "" # factory service id, (configurable)
             - "@logger"
-            - ""
+            - "" # cacheadapter id (configurable, entity_tracker.cache by default)
         tags:
             - { name: doctrine.event_listener, event: entityChanged, priority: 16 }
             - { name: doctrine.event_listener, event: postFlush, priority: 20 }

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -19,7 +19,7 @@ services:
             - "@entity_tracker.provider.annotation_metadata"
             - "@entity_tracker.provider.mutation_metadata"
             - "@?logger"
-            - ""
+            - "" # cacheadapter id (configurable, entity_tracker.cache by default)
         tags:
             - { name: doctrine.event_listener, event: preFlush, priority: 15 }
             - { name: doctrine.event_listener, event: prePersist, priority: 15 }

--- a/src/Resources/config/services.yaml
+++ b/src/Resources/config/services.yaml
@@ -1,4 +1,7 @@
 services:
+    entity_tracker.cache:
+        class: Symfony\Component\Cache\Adapter\ArrayAdapter
+
     entity_tracker.provider.annotation_metadata:
         class: Hostnet\Component\EntityTracker\Provider\EntityAnnotationMetadataProvider
         arguments:
@@ -16,6 +19,7 @@ services:
             - "@entity_tracker.provider.annotation_metadata"
             - "@entity_tracker.provider.mutation_metadata"
             - "@?logger"
+            - ""
         tags:
             - { name: doctrine.event_listener, event: preFlush, priority: 15 }
             - { name: doctrine.event_listener, event: prePersist, priority: 15 }

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -40,7 +40,10 @@ class ConfigurationTest extends TestCase
         $processor     = new Processor();
         $configuration = new Configuration();
 
-        self::assertSame(['cache' => 'entity_tracker.cache'], $processor->processConfiguration($configuration, $configs));
+        self::assertSame(
+            ['cache' => 'entity_tracker.cache'],
+            $processor->processConfiguration($configuration, $configs)
+        );
     }
 
     public function emptyConfigProvider(): array

--- a/tests/DependencyInjection/ConfigurationTest.php
+++ b/tests/DependencyInjection/ConfigurationTest.php
@@ -21,6 +21,7 @@ class ConfigurationTest extends TestCase
                 'blamable' => ['provider' => 'henk', 'default_username' => 'eux'],
                 'revision' => ['factory' => 'henk'],
                 'mutation' => [],
+                'cache'    => 'entity_tracker.cache',
             ],
         ];
 
@@ -39,7 +40,7 @@ class ConfigurationTest extends TestCase
         $processor     = new Processor();
         $configuration = new Configuration();
 
-        self::assertEmpty($processor->processConfiguration($configuration, $configs));
+        self::assertSame(['cache' => 'entity_tracker.cache'], $processor->processConfiguration($configuration, $configs));
     }
 
     public function emptyConfigProvider(): array


### PR DESCRIPTION
- needs https://github.com/hostnet/entity-blamable-component/pull/19
- configures a centralized cache for the entity-tracker-component, entity-blamable-component, entity-revision-component and entity-mutation component, saving on attribute / annotation lookups